### PR TITLE
Set default host for resources

### DIFF
--- a/lib/ided_client/base_resource.rb
+++ b/lib/ided_client/base_resource.rb
@@ -9,5 +9,8 @@ module IdedClient
     def self.host=(host)
       self.site = "#{host}/api/v1"
     end
+
+    # Set the default host for resources.
+    self.host = "https://auth.ided.io"
   end
 end

--- a/spec/lib/ided_client/team_spec.rb
+++ b/spec/lib/ided_client/team_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe IdedClient::Team do
     let(:credential) { IdedClient::Credential.new(access_token: "pizza", credential_key: "fake") }
 
     before do
-      IdedClient::BaseResource.site = "http://ided.localhost"
-      stub_request(:get, "http://ided.localhost/teams")
+      stub_request(:get, "https://auth.ided.io/api/v1/teams")
         .with(
           headers: {
             "Accept" => "application/vnd.api+json",


### PR DESCRIPTION
Why: So that setup does not need to be called.