### PR TITLE
Refactor request helper to work with grape

### DIFF
--- a/lib/ided_client/wrapper.rb
+++ b/lib/ided_client/wrapper.rb
@@ -11,8 +11,11 @@ module IdedClient
     end
 
     def credential_from_request(request)
+      auth_header = request.headers["Authorization"]
+      return if auth_header.nil?
+
       Credential.new(
-        access_token: request.authorization.sub(/^Bearer /, ""),
+        access_token: auth_header.sub(/^Bearer /, ""),
         credential_key: credential_key,
       )
     end

--- a/spec/lib/ided_client/wrapper_spec.rb
+++ b/spec/lib/ided_client/wrapper_spec.rb
@@ -4,14 +4,24 @@ RSpec.describe IdedClient::Wrapper do
   subject { described_class.new }
 
   describe "#credential_from_request" do
-    let(:request) { double(authorization: "Bearer pizza") }
+    let(:request) { double(headers: headers) }
     let(:cred) { double(cred) }
+    let(:headers) { { "Authorization" => "Bearer pizza" } }
+
     before do
       allow(subject).to receive(:credential_key).and_return("fake key")
     end
 
     it "builds the credential from the authorization header" do
       expect(subject.credential_from_request(request).access_token).to eql("pizza")
+    end
+
+    context "there is no authorization header" do
+      let(:headers) { {} }
+
+      it "returns nil" do
+        expect(subject.credential_from_request(request)).to eql(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
Why: Grape does not have a authorization method like rails.