### PR TITLE
Refresh token

### DIFF
--- a/lib/ided_client/auth.rb
+++ b/lib/ided_client/auth.rb
@@ -12,15 +12,20 @@ module IdedClient
 
     def exchange_code_for_credential(code)
       token = exchange_code(code)
-      build_credential(access_token: token.token)
+      build_credential(access_token: token.token, refresh_token: token.refresh_token)
     end
 
     def authorize_url
       oauth_client.auth_code.authorize_url(redirect_uri: redirect_uri)
     end
 
-    def build_credential(access_token:)
-      Credential.new(access_token: access_token, credential_key: credential_key)
+    def build_credential(access_token:, refresh_token:)
+      Credential.new(access_token: access_token, refresh_token: refresh_token, credential_key: credential_key)
+    end
+
+    def exchange_refresh_token(refresh_token)
+      new_token = oauth_client.get_token(grant_type: 'refresh_token', refresh_token: refresh_token)
+      build_credential(access_token: new_token.token, refresh_token: new_token.refresh_token)
     end
 
     private

--- a/lib/ided_client/credential.rb
+++ b/lib/ided_client/credential.rb
@@ -2,10 +2,11 @@ require 'digest/md5'
 
 module IdedClient
   class Credential
-    attr_reader :access_token
+    attr_reader :access_token, :refresh_token
 
-    def initialize(access_token:, credential_key:)
+    def initialize(access_token:, refresh_token: nil, credential_key:)
       @access_token = access_token
+      @refresh_token = refresh_token
       @credential_key = credential_key
     end
 

--- a/lib/ided_client/version.rb
+++ b/lib/ided_client/version.rb
@@ -1,3 +1,3 @@
 module IdedClient
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/spec/lib/ided_client/auth_spec.rb
+++ b/spec/lib/ided_client/auth_spec.rb
@@ -20,12 +20,13 @@ RSpec.describe IdedClient::Auth do
   describe "#exchange_code_for_credential" do
     let(:code) { "i like cheese" }
     let(:token) { "dummy-token" }
+    let(:refresh_token) { "dummy-refresh-token"}
     let(:response) {
       {
         "token_type" => "Bearer",
         "created_at" => 1550655570,
         :access_token => token,
-        :refresh_token => nil,
+        :refresh_token => refresh_token,
         :expires_at => 1550662770,
       }
     }
@@ -53,6 +54,7 @@ RSpec.describe IdedClient::Auth do
     it "allows for the auth code to be exchanged for a token" do
       credential = subject.exchange_code_for_credential(code)
       expect(credential.access_token).to eql("dummy-token")
+      expect(credential.refresh_token).to eql("dummy-refresh-token")
     end
   end
 
@@ -61,6 +63,45 @@ RSpec.describe IdedClient::Auth do
       expect(subject.authorize_url).to eql(
         "https://ided.localhost/oauth/authorize?client_id=pizza&redirect_uri=https%3A%2F%2Ftest.localhost&response_type=code"
       )
+    end
+  end
+
+  describe "#exchange_refresh_token" do
+    let(:token) { "dummy-token" }
+    let(:refresh_token) { "dummy-refresh-token" }
+    let(:response) {
+      {
+        "token_type" => "Bearer",
+        "created_at" => 1550655570,
+        :access_token => token,
+        :refresh_token => refresh_token,
+        :expires_at => 1550662770,
+      }
+    }
+
+    before do
+      stub_request(:post, "https://ided.localhost/oauth/token")
+        .with(
+          body: {
+            "client_id" => "pizza",
+            "client_secret" => "chips",
+            "refresh_token" => "i like fresh cheese",
+            "grant_type" => "refresh_token"
+          },
+          headers: {
+            "Content-Type" => "application/x-www-form-urlencoded",
+          },
+        ).to_return(
+          status: 200,
+          body: response.to_json,
+          headers: { 'Content-Type': "application/json" },
+        )
+    end
+
+    it "exchanges a refresh token for a credential" do
+      credential = subject.exchange_refresh_token("i like fresh cheese")
+      expect(credential.access_token).to eql("dummy-token")
+      expect(credential.refresh_token).to eql("dummy-refresh-token")
     end
   end
 end

--- a/spec/lib/ided_client/credential_spec.rb
+++ b/spec/lib/ided_client/credential_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe IdedClient::Credential do
-  subject { described_class.new(access_token: access_token, credential_key: rsa_public) }
+  subject { described_class.new(access_token: access_token, refresh_token: nil, credential_key: rsa_public) }
   let(:rsa_private) { OpenSSL::PKey::RSA.generate 2048 }
   let(:rsa_public) { rsa_private.public_key }
 


### PR DESCRIPTION
Why: To let the apps handle refreshing tokens